### PR TITLE
fix: handle null values in filters

### DIFF
--- a/src/components/modals/RawDataModal.tsx
+++ b/src/components/modals/RawDataModal.tsx
@@ -29,8 +29,11 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
   // Filter data based on search term
   const filteredData = sourceData.filter(row => {
     if (!searchTerm) return true;
-    return Object.values(row).some(value => 
-      value?.toString().toLowerCase().includes(searchTerm.toLowerCase())
+    return Object.values(row).some(value =>
+      (value ?? '')
+        .toString()
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase())
     );
   });
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -38,9 +38,12 @@ const Index = () => {
   // Filter data based on current filters
   const filterData = (data: KPIRecord[]) => {
     return data.filter(item => {
-      const matchesSearch = !filters.searchTerm || 
-        Object.values(item).some(value => 
-          value?.toString().toLowerCase().includes(filters.searchTerm.toLowerCase())
+      const matchesSearch = !filters.searchTerm ||
+        Object.values(item).some(value =>
+          (value ?? '')
+            .toString()
+            .toLowerCase()
+            .includes(filters.searchTerm.toLowerCase())
         );
       
       const matchesGroup = !filters.selectedGroup || 


### PR DESCRIPTION
## Summary
- prevent filtering errors by safely coercing undefined/null values to strings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_68aae31b87208321bc29f77619f2f584