### PR TITLE
Fix filter dropdown empty value causing Radix Select error

### DIFF
--- a/src/components/dashboard/FilterPanel.tsx
+++ b/src/components/dashboard/FilterPanel.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Search, RotateCcw, Filter } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RotateCcw, Filter, X } from "lucide-react";
 import { KPIRecord, FilterState } from "@/types/kpi";
 
 interface FilterPanelProps {
@@ -15,32 +21,97 @@ interface FilterPanelProps {
 export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Extract unique values for filter options
-  const uniqueGroups = [...new Set(data.map(item => item['ประเด็นขับเคลื่อน']).filter(Boolean))];
-  const uniqueMainKPIs = [...new Set(data.map(item => item['ตัวชี้วัดหลัก']).filter(Boolean))];
-  const uniqueSubKPIs = [...new Set(data.map(item => item['ตัวชี้วัดย่อย']).filter(Boolean))];
-  const uniqueTargets = [...new Set(data.map(item => item['กลุ่มเป้าหมาย']).filter(Boolean))];
-  const uniqueServices = [...new Set(data.map(item => item['ชื่อหน่วยบริการ']).filter(Boolean))];
+  const itemClass = "whitespace-normal break-words";
+
+  // Build cascading filter options based on current selections
+  const filteredByGroup = filters.selectedGroup
+    ? data.filter(item => item['ประเด็นขับเคลื่อน'] === filters.selectedGroup)
+    : data;
+  const filteredByMainKPI = filters.selectedMainKPI
+    ? filteredByGroup.filter(item => item['ตัวชี้วัดหลัก'] === filters.selectedMainKPI)
+    : filteredByGroup;
+  const filteredBySubKPI = filters.selectedSubKPI
+    ? filteredByMainKPI.filter(item => item['ตัวชี้วัดย่อย'] === filters.selectedSubKPI)
+    : filteredByMainKPI;
+  const filteredByTarget = filters.selectedTarget
+    ? filteredBySubKPI.filter(item => item['กลุ่มเป้าหมาย'] === filters.selectedTarget)
+    : filteredBySubKPI;
+
+  const uniqueGroups = [
+    ...new Set(data.map(item => item['ประเด็นขับเคลื่อน']).filter(Boolean))
+  ];
+  const uniqueMainKPIs = [
+    ...new Set(filteredByGroup.map(item => item['ตัวชี้วัดหลัก']).filter(Boolean))
+  ];
+  const uniqueSubKPIs = [
+    ...new Set(filteredByMainKPI.map(item => item['ตัวชี้วัดย่อย']).filter(Boolean))
+  ];
+  const uniqueTargets = [
+    ...new Set(filteredBySubKPI.map(item => item['กลุ่มเป้าหมาย']).filter(Boolean))
+  ];
+  const uniqueServices = [
+    ...new Set(filteredByTarget.map(item => item['ชื่อหน่วยบริการ']).filter(Boolean))
+  ];
 
   const handleFilterChange = (key: keyof FilterState, value: string) => {
-    onFiltersChange({
+    const normalizedValue = value === 'all' ? '' : value;
+    const updated: FilterState = {
       ...filters,
-      [key]: value
-    });
+      [key]: normalizedValue
+    };
+
+    // Reset dependent filters when parent selection changes
+    if (key === "selectedGroup") {
+      updated.selectedMainKPI = "";
+      updated.selectedSubKPI = "";
+      updated.selectedTarget = "";
+      updated.selectedService = "";
+    } else if (key === "selectedMainKPI") {
+      updated.selectedSubKPI = "";
+      updated.selectedTarget = "";
+      updated.selectedService = "";
+    } else if (key === "selectedSubKPI") {
+      updated.selectedTarget = "";
+      updated.selectedService = "";
+    } else if (key === "selectedTarget") {
+      updated.selectedService = "";
+    }
+
+    onFiltersChange(updated);
+  };
+
+  const handleStatusChange = (status: string, checked: boolean) => {
+    const updated: FilterState = {
+      ...filters,
+      statusFilters: checked
+        ? [...filters.statusFilters, status]
+        : filters.statusFilters.filter(s => s !== status)
+    };
+    onFiltersChange(updated);
+  };
+
+  const removeFilter = (key: keyof FilterState, value?: string) => {
+    if (key === "statusFilters" && value) {
+      handleStatusChange(value, false);
+      return;
+    }
+    handleFilterChange(key, "all");
   };
 
   const resetFilters = () => {
     onFiltersChange({
-      searchTerm: '',
-      selectedGroup: '',
-      selectedMainKPI: '',
-      selectedSubKPI: '',
-      selectedTarget: '',
-      selectedService: ''
+      selectedGroup: "",
+      selectedMainKPI: "",
+      selectedSubKPI: "",
+      selectedTarget: "",
+      selectedService: "",
+      statusFilters: []
     });
   };
 
-  const hasActiveFilters = Object.values(filters).some(value => value !== '');
+  const hasActiveFilters = Object.values(filters).some(value =>
+    Array.isArray(value) ? value.length > 0 : value !== ""
+  );
 
   return (
     <Card className="p-6">
@@ -66,17 +137,6 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
         </div>
       </div>
 
-      {/* Search Bar - Always visible */}
-      <div className="relative mb-4">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-        <Input
-          placeholder="ค้นหาตัวชี้วัด หน่วยบริการ หรือข้อมูลอื่นๆ..."
-          value={filters.searchTerm}
-          onChange={(e) => handleFilterChange('searchTerm', e.target.value)}
-          className="pl-10"
-        />
-      </div>
-
       {/* Advanced Filters - Collapsible */}
       {isExpanded && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -91,10 +151,10 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกประเด็นขับเคลื่อน" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={itemClass}>ทั้งหมด</SelectItem>
                 {uniqueGroups.map(group => (
-                  <SelectItem key={group} value={group}>{group}</SelectItem>
+                  <SelectItem key={group} value={group} className={itemClass}>{group}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -111,10 +171,10 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกตัวชี้วัดหลัก" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={itemClass}>ทั้งหมด</SelectItem>
                 {uniqueMainKPIs.map(kpi => (
-                  <SelectItem key={kpi} value={kpi}>{kpi}</SelectItem>
+                  <SelectItem key={kpi} value={kpi} className={itemClass}>{kpi}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -131,10 +191,10 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกตัวชี้วัดย่อย" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={itemClass}>ทั้งหมด</SelectItem>
                 {uniqueSubKPIs.map(kpi => (
-                  <SelectItem key={kpi} value={kpi}>{kpi}</SelectItem>
+                  <SelectItem key={kpi} value={kpi} className={itemClass}>{kpi}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -151,10 +211,10 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกกลุ่มเป้าหมาย" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={itemClass}>ทั้งหมด</SelectItem>
                 {uniqueTargets.map(target => (
-                  <SelectItem key={target} value={target}>{target}</SelectItem>
+                  <SelectItem key={target} value={target} className={itemClass}>{target}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -164,20 +224,49 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
             <label className="text-sm font-medium text-foreground mb-2 block">
               หน่วยบริการ
             </label>
-            <Select 
-              value={filters.selectedService} 
-              onValueChange={(value) => handleFilterChange('selectedService', value)}
+            <Select
+              value={filters.selectedService}
+              onValueChange={(value) => handleFilterChange("selectedService", value)}
             >
               <SelectTrigger>
                 <SelectValue placeholder="เลือกหน่วยบริการ" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={itemClass}>ทั้งหมด</SelectItem>
                 {uniqueServices.map(service => (
-                  <SelectItem key={service} value={service}>{service}</SelectItem>
+                  <SelectItem key={service} value={service} className={itemClass}>{service}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-foreground mb-2 block">
+              สถานะ
+            </label>
+            <div className="space-y-2">
+              <label className="flex items-center space-x-2">
+                <Checkbox
+                  checked={filters.statusFilters.includes('passed')}
+                  onCheckedChange={checked => handleStatusChange('passed', checked as boolean)}
+                />
+                <span>ผ่าน</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <Checkbox
+                  checked={filters.statusFilters.includes('near')}
+                  onCheckedChange={checked => handleStatusChange('near', checked as boolean)}
+                />
+                <span>ใกล้เป้า</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <Checkbox
+                  checked={filters.statusFilters.includes('failed')}
+                  onCheckedChange={checked => handleStatusChange('failed', checked as boolean)}
+                />
+                <span>ไม่ผ่าน</span>
+              </label>
+            </div>
           </div>
         </div>
       )}
@@ -186,29 +275,76 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
         <div className="mt-4 pt-4 border-t">
           <div className="flex flex-wrap gap-2">
             {filters.selectedGroup && (
-              <span className="px-3 py-1 bg-primary/10 text-primary text-sm rounded-full">
-                ประเด็น: {filters.selectedGroup}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedGroup')}
+                className="flex items-center gap-1 px-3 py-1 bg-primary/10 text-primary text-sm rounded-full"
+              >
+                <span>ประเด็น: {filters.selectedGroup}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedMainKPI && (
-              <span className="px-3 py-1 bg-secondary text-secondary-foreground text-sm rounded-full">
-                ตัวชี้วัดหลัก: {filters.selectedMainKPI}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedMainKPI')}
+                className="flex items-center gap-1 px-3 py-1 bg-secondary text-secondary-foreground text-sm rounded-full"
+              >
+                <span>ตัวชี้วัดหลัก: {filters.selectedMainKPI}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedSubKPI && (
-              <span className="px-3 py-1 bg-accent text-accent-foreground text-sm rounded-full">
-                ตัวชี้วัดย่อย: {filters.selectedSubKPI}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedSubKPI')}
+                className="flex items-center gap-1 px-3 py-1 bg-accent text-accent-foreground text-sm rounded-full"
+              >
+                <span>ตัวชี้วัดย่อย: {filters.selectedSubKPI}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedTarget && (
-              <span className="px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full">
-                เป้าหมาย: {filters.selectedTarget}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedTarget')}
+                className="flex items-center gap-1 px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full"
+              >
+                <span>เป้าหมาย: {filters.selectedTarget}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedService && (
-              <span className="px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full">
-                หน่วยบริการ: {filters.selectedService}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedService')}
+                className="flex items-center gap-1 px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full"
+              >
+                <span>หน่วยบริการ: {filters.selectedService}</span>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {filters.statusFilters.includes('passed') && (
+              <button
+                onClick={() => removeFilter('statusFilters', 'passed')}
+                className="flex items-center gap-1 px-3 py-1 bg-success/10 text-success text-sm rounded-full"
+              >
+                <span>สถานะ: ผ่าน</span>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {filters.statusFilters.includes('near') && (
+              <button
+                onClick={() => removeFilter('statusFilters', 'near')}
+                className="flex items-center gap-1 px-3 py-1 bg-warning/10 text-warning text-sm rounded-full"
+              >
+                <span>สถานะ: ใกล้เป้า</span>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {filters.statusFilters.includes('failed') && (
+              <button
+                onClick={() => removeFilter('statusFilters', 'failed')}
+                className="flex items-center gap-1 px-3 py-1 bg-destructive/10 text-destructive text-sm rounded-full"
+              >
+                <span>สถานะ: ไม่ผ่าน</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
           </div>
         </div>

--- a/src/types/kpi.ts
+++ b/src/types/kpi.ts
@@ -80,10 +80,10 @@ export interface APIResponse<T> {
 }
 
 export interface FilterState {
-  searchTerm: string;
   selectedGroup: string;
   selectedMainKPI: string;
   selectedSubKPI: string;
   selectedTarget: string;
   selectedService: string;
+  statusFilters: string[];
 }


### PR DESCRIPTION
## Summary
- render dropdown content with solid background and wrap long options to avoid transparent overlap
- make filter tags clickable to remove their associated selection

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype; Unexpected any; A require() style import is forbidden)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae5ba7ae883218914f257e49f06ab