### PR TITLE
Improve status filtering and service selection

### DIFF
--- a/src/components/dashboard/FilterPanel.tsx
+++ b/src/components/dashboard/FilterPanel.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Search, RotateCcw, Filter } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RotateCcw, Filter, X } from "lucide-react";
 import { KPIRecord, FilterState } from "@/types/kpi";
 
 interface FilterPanelProps {
@@ -15,32 +21,93 @@ interface FilterPanelProps {
 export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Extract unique values for filter options
-  const uniqueGroups = [...new Set(data.map(item => item['ประเด็นขับเคลื่อน']).filter(Boolean))];
-  const uniqueMainKPIs = [...new Set(data.map(item => item['ตัวชี้วัดหลัก']).filter(Boolean))];
-  const uniqueSubKPIs = [...new Set(data.map(item => item['ตัวชี้วัดย่อย']).filter(Boolean))];
-  const uniqueTargets = [...new Set(data.map(item => item['กลุ่มเป้าหมาย']).filter(Boolean))];
-  const uniqueServices = [...new Set(data.map(item => item['ชื่อหน่วยบริการ']).filter(Boolean))];
+  // Utility class reused by all SelectItem entries
+  const optionClass = "whitespace-normal break-words line-clamp-2";
+
+  // Build cascading filter options based on current selections
+  const filteredByGroup = filters.selectedGroup
+    ? data.filter(item => item['ประเด็นขับเคลื่อน'] === filters.selectedGroup)
+    : data;
+  const filteredByMainKPI = filters.selectedMainKPI
+    ? filteredByGroup.filter(item => item['ตัวชี้วัดหลัก'] === filters.selectedMainKPI)
+    : filteredByGroup;
+  const filteredBySubKPI = filters.selectedSubKPI
+    ? filteredByMainKPI.filter(item => item['ตัวชี้วัดย่อย'] === filters.selectedSubKPI)
+    : filteredByMainKPI;
+  const filteredByTarget = filters.selectedTarget
+    ? filteredBySubKPI.filter(item => item['กลุ่มเป้าหมาย'] === filters.selectedTarget)
+    : filteredBySubKPI;
+
+  const uniqueGroups = [
+    ...new Set(data.map(item => item['ประเด็นขับเคลื่อน']).filter(Boolean))
+  ];
+  const uniqueMainKPIs = [
+    ...new Set(filteredByGroup.map(item => item['ตัวชี้วัดหลัก']).filter(Boolean))
+  ];
+  const uniqueSubKPIs = [
+    ...new Set(filteredByMainKPI.map(item => item['ตัวชี้วัดย่อย']).filter(Boolean))
+  ];
+  const uniqueTargets = [
+    ...new Set(filteredBySubKPI.map(item => item['กลุ่มเป้าหมาย']).filter(Boolean))
+  ];
+  const uniqueServices = [
+    ...new Set(data.map(item => item['ชื่อหน่วยบริการ']).filter(Boolean))
+  ];
 
   const handleFilterChange = (key: keyof FilterState, value: string) => {
-    onFiltersChange({
+    const normalizedValue = value === 'all' ? '' : value;
+    const updated: FilterState = {
       ...filters,
-      [key]: value
-    });
+      [key]: normalizedValue
+    };
+
+    // Reset dependent filters when parent selection changes
+    if (key === "selectedGroup") {
+      updated.selectedMainKPI = "";
+      updated.selectedSubKPI = "";
+      updated.selectedTarget = "";
+    } else if (key === "selectedMainKPI") {
+      updated.selectedSubKPI = "";
+      updated.selectedTarget = "";
+    } else if (key === "selectedSubKPI") {
+      updated.selectedTarget = "";
+    }
+
+    onFiltersChange(updated);
+  };
+
+  const handleStatusChange = (status: string, checked: boolean) => {
+    const updated: FilterState = {
+      ...filters,
+      statusFilters: checked
+        ? [...filters.statusFilters, status]
+        : filters.statusFilters.filter(s => s !== status)
+    };
+    onFiltersChange(updated);
+  };
+
+  const removeFilter = (key: keyof FilterState, value?: string) => {
+    if (key === "statusFilters" && value) {
+      handleStatusChange(value, false);
+      return;
+    }
+    handleFilterChange(key, "all");
   };
 
   const resetFilters = () => {
     onFiltersChange({
-      searchTerm: '',
-      selectedGroup: '',
-      selectedMainKPI: '',
-      selectedSubKPI: '',
-      selectedTarget: '',
-      selectedService: ''
+      selectedGroup: "",
+      selectedMainKPI: "",
+      selectedSubKPI: "",
+      selectedTarget: "",
+      selectedService: "",
+      statusFilters: []
     });
   };
 
-  const hasActiveFilters = Object.values(filters).some(value => value !== '');
+  const hasActiveFilters = Object.values(filters).some(value =>
+    Array.isArray(value) ? value.length > 0 : value !== ""
+  );
 
   return (
     <Card className="p-6">
@@ -66,17 +133,6 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
         </div>
       </div>
 
-      {/* Search Bar - Always visible */}
-      <div className="relative mb-4">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-        <Input
-          placeholder="ค้นหาตัวชี้วัด หน่วยบริการ หรือข้อมูลอื่นๆ..."
-          value={filters.searchTerm}
-          onChange={(e) => handleFilterChange('searchTerm', e.target.value)}
-          className="pl-10"
-        />
-      </div>
-
       {/* Advanced Filters - Collapsible */}
       {isExpanded && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -91,10 +147,17 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกประเด็นขับเคลื่อน" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={optionClass}>ทั้งหมด</SelectItem>
                 {uniqueGroups.map(group => (
-                  <SelectItem key={group} value={group}>{group}</SelectItem>
+                  <SelectItem
+                    key={group}
+                    value={group}
+                    className={optionClass}
+                    title={group}
+                  >
+                    {group}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -111,10 +174,17 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกตัวชี้วัดหลัก" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={optionClass}>ทั้งหมด</SelectItem>
                 {uniqueMainKPIs.map(kpi => (
-                  <SelectItem key={kpi} value={kpi}>{kpi}</SelectItem>
+                  <SelectItem
+                    key={kpi}
+                    value={kpi}
+                    className={optionClass}
+                    title={kpi}
+                  >
+                    {kpi}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -131,10 +201,17 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกตัวชี้วัดย่อย" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={optionClass}>ทั้งหมด</SelectItem>
                 {uniqueSubKPIs.map(kpi => (
-                  <SelectItem key={kpi} value={kpi}>{kpi}</SelectItem>
+                  <SelectItem
+                    key={kpi}
+                    value={kpi}
+                    className={optionClass}
+                    title={kpi}
+                  >
+                    {kpi}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -151,10 +228,17 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               <SelectTrigger>
                 <SelectValue placeholder="เลือกกลุ่มเป้าหมาย" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={optionClass}>ทั้งหมด</SelectItem>
                 {uniqueTargets.map(target => (
-                  <SelectItem key={target} value={target}>{target}</SelectItem>
+                  <SelectItem
+                    key={target}
+                    value={target}
+                    className={optionClass}
+                    title={target}
+                  >
+                    {target}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -164,20 +248,56 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
             <label className="text-sm font-medium text-foreground mb-2 block">
               หน่วยบริการ
             </label>
-            <Select 
-              value={filters.selectedService} 
-              onValueChange={(value) => handleFilterChange('selectedService', value)}
+            <Select
+              value={filters.selectedService}
+              onValueChange={(value) => handleFilterChange("selectedService", value)}
             >
               <SelectTrigger>
                 <SelectValue placeholder="เลือกหน่วยบริการ" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">ทั้งหมด</SelectItem>
+              <SelectContent className="bg-white">
+                <SelectItem value="all" className={optionClass}>ทั้งหมด</SelectItem>
                 {uniqueServices.map(service => (
-                  <SelectItem key={service} value={service}>{service}</SelectItem>
+                  <SelectItem
+                    key={service}
+                    value={service}
+                    className={optionClass}
+                    title={service}
+                  >
+                    {service}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-foreground mb-2 block">
+              สถานะ
+            </label>
+            <div className="space-y-2">
+              <label className="flex items-center space-x-2">
+                <Checkbox
+                  checked={filters.statusFilters.includes('passed')}
+                  onCheckedChange={checked => handleStatusChange('passed', checked as boolean)}
+                />
+                <span>ผ่าน</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <Checkbox
+                  checked={filters.statusFilters.includes('near')}
+                  onCheckedChange={checked => handleStatusChange('near', checked as boolean)}
+                />
+                <span>ใกล้เป้า</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <Checkbox
+                  checked={filters.statusFilters.includes('failed')}
+                  onCheckedChange={checked => handleStatusChange('failed', checked as boolean)}
+                />
+                <span>ไม่ผ่าน</span>
+              </label>
+            </div>
           </div>
         </div>
       )}
@@ -186,29 +306,76 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
         <div className="mt-4 pt-4 border-t">
           <div className="flex flex-wrap gap-2">
             {filters.selectedGroup && (
-              <span className="px-3 py-1 bg-primary/10 text-primary text-sm rounded-full">
-                ประเด็น: {filters.selectedGroup}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedGroup')}
+                className="flex items-center gap-1 px-3 py-1 bg-primary/10 text-primary text-sm rounded-full"
+              >
+                <span>ประเด็น: {filters.selectedGroup}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedMainKPI && (
-              <span className="px-3 py-1 bg-secondary text-secondary-foreground text-sm rounded-full">
-                ตัวชี้วัดหลัก: {filters.selectedMainKPI}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedMainKPI')}
+                className="flex items-center gap-1 px-3 py-1 bg-secondary text-secondary-foreground text-sm rounded-full"
+              >
+                <span>ตัวชี้วัดหลัก: {filters.selectedMainKPI}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedSubKPI && (
-              <span className="px-3 py-1 bg-accent text-accent-foreground text-sm rounded-full">
-                ตัวชี้วัดย่อย: {filters.selectedSubKPI}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedSubKPI')}
+                className="flex items-center gap-1 px-3 py-1 bg-accent text-accent-foreground text-sm rounded-full"
+              >
+                <span>ตัวชี้วัดย่อย: {filters.selectedSubKPI}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedTarget && (
-              <span className="px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full">
-                เป้าหมาย: {filters.selectedTarget}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedTarget')}
+                className="flex items-center gap-1 px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full"
+              >
+                <span>เป้าหมาย: {filters.selectedTarget}</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
             {filters.selectedService && (
-              <span className="px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full">
-                หน่วยบริการ: {filters.selectedService}
-              </span>
+              <button
+                onClick={() => removeFilter('selectedService')}
+                className="flex items-center gap-1 px-3 py-1 bg-muted text-muted-foreground text-sm rounded-full"
+              >
+                <span>หน่วยบริการ: {filters.selectedService}</span>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {filters.statusFilters.includes('passed') && (
+              <button
+                onClick={() => removeFilter('statusFilters', 'passed')}
+                className="flex items-center gap-1 px-3 py-1 bg-success/10 text-success text-sm rounded-full"
+              >
+                <span>สถานะ: ผ่าน</span>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {filters.statusFilters.includes('near') && (
+              <button
+                onClick={() => removeFilter('statusFilters', 'near')}
+                className="flex items-center gap-1 px-3 py-1 bg-warning/10 text-warning text-sm rounded-full"
+              >
+                <span>สถานะ: ใกล้เป้า</span>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {filters.statusFilters.includes('failed') && (
+              <button
+                onClick={() => removeFilter('statusFilters', 'failed')}
+                className="flex items-center gap-1 px-3 py-1 bg-destructive/10 text-destructive text-sm rounded-full"
+              >
+                <span>สถานะ: ไม่ผ่าน</span>
+                <X className="h-3 w-3" />
+              </button>
             )}
           </div>
         </div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-2 [&>span]:whitespace-normal [&>span]:text-left",
       className
     )}
     {...props}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,9 +7,53 @@ import { KPIGroupCards } from "@/components/dashboard/KPIGroupCards";
 import { KPIDetailTable } from "@/components/dashboard/KPIDetailTable";
 import { KPIInfoModal } from "@/components/modals/KPIInfoModal";
 import { RawDataModal } from "@/components/modals/RawDataModal";
-import { FilterState, KPIRecord } from "@/types/kpi";
+import { FilterState, KPIRecord, SummaryStats } from "@/types/kpi";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+
+const calculateSummary = (data: KPIRecord[]): SummaryStats => {
+  const summary: SummaryStats = {
+    totalKPIs: data.length,
+    averagePercentage: 0,
+    passedKPIs: 0,
+    failedKPIs: 0,
+    groupStats: {}
+  };
+
+  data.forEach(item => {
+    const percentage = parseFloat(item['ร้อยละ (%)']?.toString() || '0');
+    const threshold = parseFloat(item['เกณฑ์ผ่าน (%)']?.toString() || '0');
+    const passed = percentage >= threshold;
+
+    if (passed) summary.passedKPIs++; else summary.failedKPIs++;
+    summary.averagePercentage += percentage;
+
+    const group = item['ประเด็นขับเคลื่อน'];
+    if (!summary.groupStats[group]) {
+      summary.groupStats[group] = {
+        count: 0,
+        totalPercentage: 0,
+        passed: 0,
+        failed: 0,
+        averagePercentage: 0
+      };
+    }
+    const g = summary.groupStats[group];
+    g.count++;
+    g.totalPercentage += percentage;
+    if (passed) g.passed++; else g.failed++;
+  });
+
+  Object.values(summary.groupStats).forEach(g => {
+    g.averagePercentage = g.count > 0 ? g.totalPercentage / g.count : 0;
+  });
+
+  summary.averagePercentage = summary.totalKPIs > 0
+    ? summary.averagePercentage / summary.totalKPIs
+    : 0;
+
+  return summary;
+};
 
 const Index = () => {
   const { allData, loading, error, refetch } = useKPIData();
@@ -26,43 +70,67 @@ const Index = () => {
   const [selectedRecord, setSelectedRecord] = useState<KPIRecord | null>(null);
   
   // Filter state
-  const [filters, setFilters] = useState<FilterState>({
-    searchTerm: '',
+  const initialFilters: FilterState = {
     selectedGroup: '',
     selectedMainKPI: '',
     selectedSubKPI: '',
     selectedTarget: '',
-    selectedService: ''
-  });
+    selectedService: '',
+    statusFilters: []
+  };
+  const [filters, setFilters] = useState<FilterState>(initialFilters);
 
-  // Filter data based on current filters
-  const filterData = (data: KPIRecord[]) => {
+  // Apply cascading filters excluding status
+  const applyBasicFilters = (data: KPIRecord[]) => {
     return data.filter(item => {
-      const matchesSearch = !filters.searchTerm ||
-        Object.values(item).some(value =>
-          (value ?? '')
-            .toString()
-            .toLowerCase()
-            .includes(filters.searchTerm.toLowerCase())
-        );
-      
-      const matchesGroup = !filters.selectedGroup || 
+      const matchesGroup = !filters.selectedGroup ||
         item['ประเด็นขับเคลื่อน'] === filters.selectedGroup;
-      
-      const matchesMainKPI = !filters.selectedMainKPI || 
+      const matchesMainKPI = !filters.selectedMainKPI ||
         item['ตัวชี้วัดหลัก'] === filters.selectedMainKPI;
-      
-      const matchesSubKPI = !filters.selectedSubKPI || 
+      const matchesSubKPI = !filters.selectedSubKPI ||
         item['ตัวชี้วัดย่อย'] === filters.selectedSubKPI;
-      
-      const matchesTarget = !filters.selectedTarget || 
+      const matchesTarget = !filters.selectedTarget ||
         item['กลุ่มเป้าหมาย'] === filters.selectedTarget;
-      
-      const matchesService = !filters.selectedService || 
+      const matchesService = !filters.selectedService ||
         item['ชื่อหน่วยบริการ'] === filters.selectedService;
+      return (
+        matchesGroup &&
+        matchesMainKPI &&
+        matchesSubKPI &&
+        matchesTarget &&
+        matchesService
+      );
+    });
+  };
 
-      return matchesSearch && matchesGroup && matchesMainKPI && 
-             matchesSubKPI && matchesTarget && matchesService;
+  // Apply status filters based on current view
+  const applyStatusFilter = (data: KPIRecord[]) => {
+    if (filters.statusFilters.length === 0) return data;
+
+    if (currentView === 'groups') {
+      const groupStats = calculateSummary(data).groupStats;
+      const groupStatusMap: Record<string, string> = Object.entries(groupStats).reduce((acc, [group, stats]) => {
+        const avg = stats?.averagePercentage || 0;
+        const status = avg >= 80 ? 'passed' : avg >= 60 ? 'near' : 'failed';
+        acc[group] = status;
+        return acc;
+      }, {} as Record<string, string>);
+
+      return data.filter(item => {
+        const status = groupStatusMap[item['ประเด็นขับเคลื่อน']] || 'failed';
+        return filters.statusFilters.includes(status);
+      });
+    }
+
+    return data.filter(item => {
+      const percentage = parseFloat(item['ร้อยละ (%)']?.toString() || '0');
+      const threshold = parseFloat(item['เกณฑ์ผ่าน (%)']?.toString() || '0');
+      const status = percentage >= threshold
+        ? 'passed'
+        : percentage >= threshold * 0.8
+          ? 'near'
+          : 'failed';
+      return filters.statusFilters.includes(status);
     });
   };
 
@@ -75,6 +143,7 @@ const Index = () => {
   const handleBackToGroups = () => {
     setCurrentView('groups');
     setSelectedGroup('');
+    setFilters(initialFilters);
   };
 
   const handleKPIInfoClick = (kpiInfoId: string) => {
@@ -127,14 +196,16 @@ const Index = () => {
     );
   }
 
-  const filteredData = filterData(allData.configuration);
+  const basicFilteredData = applyBasicFilters(allData.configuration);
+  const filteredData = applyStatusFilter(basicFilteredData);
+  const filteredSummary = calculateSummary(filteredData);
 
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-8 space-y-8">
         {/* Dashboard Header */}
-        <DashboardHeader 
-          summary={allData.summary} 
+        <DashboardHeader
+          summary={filteredSummary}
           lastUpdate={allData.metadata?.lastUpdate}
         />
 
@@ -147,9 +218,9 @@ const Index = () => {
 
         {/* Main Content */}
         {currentView === 'groups' ? (
-          <KPIGroupCards 
+          <KPIGroupCards
             data={filteredData}
-            summary={allData.summary}
+            summary={filteredSummary}
             onGroupClick={handleGroupClick}
           />
         ) : (

--- a/src/types/kpi.ts
+++ b/src/types/kpi.ts
@@ -80,10 +80,10 @@ export interface APIResponse<T> {
 }
 
 export interface FilterState {
-  searchTerm: string;
   selectedGroup: string;
   selectedMainKPI: string;
   selectedSubKPI: string;
   selectedTarget: string;
   selectedService: string;
+  statusFilters: string[];
 }


### PR DESCRIPTION
## Summary
- render dropdown content with solid background and wrap long options to avoid transparent overlap
- make filter tags clickable to remove their associated selection
- clamp long filter option labels to two lines and show full text on hover
- derive status filter from group averages in overview and per-KPI percentages in detail view
- let the service filter work independently of the KPI hierarchy
- recompute overview cards and success bar from the filtered KPI list
- rename dropdown item class to avoid redeclaration error in filter panel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 8 errors, 7 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae5ba7ae883218914f257e49f06ab