### PR TITLE
Handle missing KPI targets in percentage calculations

### DIFF
--- a/src/components/dashboard/KPIDetailTable.tsx
+++ b/src/components/dashboard/KPIDetailTable.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { ArrowUpDown, ChevronLeft, Info, Database, Calendar, Building2 } from "lucide-react";
 import { KPIRecord } from "@/types/kpi";
+import { calculatePercentage } from "@/lib/kpi";
 
 interface KPIDetailTableProps {
   data: KPIRecord[];
@@ -53,9 +54,10 @@ export const KPIDetailTable = ({
     return isNaN(num) ? value : num.toLocaleString();
   };
 
-  const formatPercentage = (value: string | number) => {
+  const formatPercentage = (value: string | number | null | undefined) => {
+    if (value === null || value === undefined || value === '') return '';
     const num = typeof value === 'string' ? parseFloat(value) : value;
-    return isNaN(num) ? value : `${num.toFixed(2)}%`;
+    return isNaN(num) ? '' : `${num.toFixed(2)}%`;
   };
 
   return (
@@ -127,7 +129,7 @@ export const KPIDetailTable = ({
                       </thead>
                       <tbody>
                         {records.map((record, index) => {
-                          const percentage = parseFloat(record['ร้อยละ (%)']?.toString() || '0');
+                          const percentage = calculatePercentage(record);
                           const threshold = parseFloat(record['เกณฑ์ผ่าน (%)']?.toString() || '0');
                           
                           return (
@@ -148,14 +150,14 @@ export const KPIDetailTable = ({
                               <td className="p-3 text-right">
                                 <div className="space-y-1">
                                   <div className="font-semibold">{formatPercentage(percentage)}</div>
-                                  <Progress value={Math.min(percentage, 100)} className="h-1.5" />
+                                  <Progress value={Math.min(percentage ?? 0, 100)} className="h-1.5" />
                                 </div>
                               </td>
                               <td className="p-3 text-right font-mono text-muted-foreground">
                                 {formatPercentage(threshold)}
                               </td>
                               <td className="p-3 text-center">
-                                {getStatusBadge(percentage, threshold)}
+                                {percentage !== null ? getStatusBadge(percentage, threshold) : '-'}
                               </td>
                               <td className="p-3">
                                 <div className="flex space-x-1 justify-center">

--- a/src/components/dashboard/KPIGroupCards.tsx
+++ b/src/components/dashboard/KPIGroupCards.tsx
@@ -44,7 +44,7 @@ export const KPIGroupCards = ({ data, summary, onGroupClick }: KPIGroupCardsProp
           const groupStats = summary.groupStats[groupName];
           const averagePercentage = groupStats?.averagePercentage || 0;
           const passedCount = groupStats?.passed || 0;
-          const totalCount = groupStats?.count || records.length;
+          const totalCount = groupStats?.count ?? 0;
           
           return (
             <Card 

--- a/src/lib/kpi.ts
+++ b/src/lib/kpi.ts
@@ -1,0 +1,27 @@
+import { KPIRecord } from '@/types/kpi';
+
+/**
+ * Calculate percentage from target and result values.
+ * Returns null when both target and result are empty or zero,
+ * or when target is zero/invalid to avoid division by zero.
+ */
+export const calculatePercentage = (record: Pick<KPIRecord, 'เป้าหมาย' | 'ผลงาน'>): number | null => {
+  const targetRaw = record['เป้าหมาย']?.toString().trim();
+  const resultRaw = record['ผลงาน']?.toString().trim();
+
+  if (
+    (!targetRaw && !resultRaw) ||
+    (targetRaw === '0' && resultRaw === '0')
+  ) {
+    return null;
+  }
+
+  const target = parseFloat(targetRaw);
+  const result = parseFloat(resultRaw);
+
+  if (isNaN(target) || target === 0 || isNaN(result)) {
+    return null;
+  }
+
+  return (result / target) * 100;
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,10 +10,11 @@ import { RawDataModal } from "@/components/modals/RawDataModal";
 import { FilterState, KPIRecord, SummaryStats } from "@/types/kpi";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { calculatePercentage } from "@/lib/kpi";
 
 const calculateSummary = (data: KPIRecord[]): SummaryStats => {
   const summary: SummaryStats = {
-    totalKPIs: data.length,
+    totalKPIs: 0,
     averagePercentage: 0,
     passedKPIs: 0,
     failedKPIs: 0,
@@ -21,10 +22,12 @@ const calculateSummary = (data: KPIRecord[]): SummaryStats => {
   };
 
   data.forEach(item => {
-    const percentage = parseFloat(item['ร้อยละ (%)']?.toString() || '0');
+    const percentage = calculatePercentage(item);
+    if (percentage === null) return;
     const threshold = parseFloat(item['เกณฑ์ผ่าน (%)']?.toString() || '0');
     const passed = percentage >= threshold;
 
+    summary.totalKPIs++;
     if (passed) summary.passedKPIs++; else summary.failedKPIs++;
     summary.averagePercentage += percentage;
 
@@ -117,13 +120,15 @@ const Index = () => {
       }, {} as Record<string, string>);
 
       return data.filter(item => {
-        const status = groupStatusMap[item['ประเด็นขับเคลื่อน']] || 'failed';
+        const status = groupStatusMap[item['ประเด็นขับเคลื่อน']];
+        if (!status) return false;
         return filters.statusFilters.includes(status);
       });
     }
 
     return data.filter(item => {
-      const percentage = parseFloat(item['ร้อยละ (%)']?.toString() || '0');
+      const percentage = calculatePercentage(item);
+      if (percentage === null) return false;
       const threshold = parseFloat(item['เกณฑ์ผ่าน (%)']?.toString() || '0');
       const status = percentage >= threshold
         ? 'passed'


### PR DESCRIPTION
## Summary
- skip KPI records with empty or zero targets when computing percentages
- centralize percentage logic in new `calculatePercentage` utility
- show blank percentages and omit status badges for incomplete data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 8 errors, 7 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab090363f88321b2b80108b4719023