### PR TITLE
fix: enable raw data source fallback

### DIFF
--- a/src/components/dashboard/KPIDetailTable.tsx
+++ b/src/components/dashboard/KPIDetailTable.tsx
@@ -132,6 +132,7 @@ export const KPIDetailTable = ({
                           const percentage = calculatePercentage(record);
                           const threshold = parseFloat(record['เกณฑ์ผ่าน (%)']?.toString() || '0');
                           const hasResult = record['ผลงาน']?.toString().trim() !== '';
+                          const sheetSource = record.sheet_source || (record as Record<string, string | undefined>)['แหล่งข้อมูล'];
 
                           return (
                             <tr key={index} className="border-b hover:bg-muted/30 transition-colors">
@@ -162,11 +163,11 @@ export const KPIDetailTable = ({
                               </td>
                               <td className="p-3">
                                 <div className="flex space-x-1 justify-center">
-                                  {record.sheet_source && (
+                                  {sheetSource && (
                                     <Button
                                       variant="ghost"
                                       size="sm"
-                                      onClick={() => onRawDataClick(record.sheet_source, record)}
+                                      onClick={() => onRawDataClick(sheetSource, record)}
                                       title="ดูข้อมูลดิบ"
                                     >
                                       <Database className="h-4 w-4" />

--- a/src/types/kpi.ts
+++ b/src/types/kpi.ts
@@ -10,7 +10,8 @@ export interface KPIRecord {
   'ร้อยละ (%)': number | string;
   'เกณฑ์ผ่าน (%)': number | string;
   'ข้อมูลวันที่': string;
-  'sheet_source': string;
+  'sheet_source'?: string;
+  'แหล่งข้อมูล'?: string;
   'service_code_ref': string;
   'kpi_info_id': string;
 }
@@ -61,14 +62,14 @@ export interface SummaryStats {
 
 export interface KPIData {
   configuration: KPIRecord[];
-  sourceData: { [key: string]: any[] };
+  sourceData: { [key: string]: unknown[] };
   groups: string[];
   summary: SummaryStats;
   metadata?: {
     totalKPIs: number;
     totalSheets: number;
     lastUpdate: string;
-  }
+  };
 }
 
 export interface APIResponse<T> {


### PR DESCRIPTION
## Summary
- allow raw data action when either `sheet_source` or Thai `แหล่งข้อมูล` field is present
- relax KPI types to support optional source fields and unknown source data structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 7 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab30ab22c483219774276ea97b4fe5