### PR TITLE
refactor: use consistent lucide icons

### DIFF
--- a/src/components/dashboard/KPIDetailTable.tsx
+++ b/src/components/dashboard/KPIDetailTable.tsx
@@ -5,6 +5,15 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { KPIRecord } from "@/types/kpi";
 import { calculatePercentage } from "@/lib/kpi";
+import {
+  AlertCircle,
+  ChevronLeft,
+  Eye,
+  History,
+  Info,
+  Table,
+  Users,
+} from "lucide-react";
 
 interface KPIDetailTableProps {
   data: KPIRecord[];
@@ -66,7 +75,7 @@ export const KPIDetailTable = ({
         <div className="flex items-center space-x-4">
           {onBack && (
             <Button variant="outline" onClick={onBack} size="sm">
-              <i className="fa-solid fa-chevron-left mr-1"></i>
+              <ChevronLeft className="h-4 w-4 mr-1" />
               กลับ
             </Button>
           )}
@@ -109,8 +118,7 @@ export const KPIDetailTable = ({
                             size="sm"
                             onClick={() => onRawDataClick(groupSheetSource)}
                           >
-                            <i className="fa-solid fa-table-list mr-1"></i>
-
+                            <Table className="h-4 w-4 mr-1" />
                             ข้อมูลทั้งหมด
                           </Button>
                         )}
@@ -120,7 +128,7 @@ export const KPIDetailTable = ({
                             size="sm"
                             onClick={() => onKPIInfoClick(records[0].kpi_info_id)}
                           >
-                            <i className="fa-solid fa-circle-info mr-1"></i>
+                            <Info className="h-4 w-4 mr-1" />
                             รายละเอียด KPI
                           </Button>
                         )}
@@ -154,7 +162,7 @@ export const KPIDetailTable = ({
                             <tr key={index} className="border-b hover:bg-muted/30 transition-colors">
                               <td className="p-3">
                                 <div className="flex items-center space-x-2">
-                                  <i className="fa-solid fa-users text-muted-foreground"></i>
+                                  <Users className="h-4 w-4 text-muted-foreground" />
                                   <span>{record['กลุ่มเป้าหมาย']}</span>
                                 </div>
                               </td>
@@ -186,7 +194,7 @@ export const KPIDetailTable = ({
                                       onClick={() => onRawDataClick(sheetSource, record)}
                                       title="เฉพาะหน่วยนี้"
                                     >
-                                      <i className="fa-solid fa-eye"></i>
+                                      <Eye className="h-4 w-4" />
                                     </Button>
                                   )}
                                 </div>
@@ -201,7 +209,7 @@ export const KPIDetailTable = ({
                   {/* Update Info */}
                   {records[0]?.['ข้อมูลวันที่'] && (
                     <div className="mt-3 pt-3 border-t text-xs text-muted-foreground flex items-center">
-                      <i className="fa-solid fa-clock-rotate-left mr-1"></i>
+                      <History className="h-4 w-4 mr-1" />
                       อัพเดทล่าสุด: {records[0]['ข้อมูลวันที่']}
                     </div>
                   )}
@@ -216,8 +224,7 @@ export const KPIDetailTable = ({
       {Object.keys(groupedData).length === 0 && (
         <Card className="p-8 text-center">
           <div className="text-muted-foreground">
-            <i className="fa-solid fa-circle-exclamation text-6xl mx-auto mb-4 opacity-50"></i>
-
+            <AlertCircle className="h-12 w-12 mx-auto mb-4 opacity-50" />
             <p className="text-lg">ไม่พบข้อมูลตัวชี้วัดที่ตรงกับเงื่อนไข</p>
           </div>
         </Card>

--- a/src/components/dashboard/KPIGroupCards.tsx
+++ b/src/components/dashboard/KPIGroupCards.tsx
@@ -1,7 +1,7 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { ChevronRight, Activity, Target, TrendingUp, Users } from "lucide-react";
+import { ChevronRight, Brain, Pill, Ribbon, Target, TrendingUp } from "lucide-react";
 import { KPIRecord, SummaryStats } from "@/types/kpi";
 
 interface KPIGroupCardsProps {
@@ -20,11 +20,14 @@ export const KPIGroupCards = ({ data, summary, onGroupClick }: KPIGroupCardsProp
   }, {} as Record<string, KPIRecord[]>);
 
   const getGroupIcon = (groupName: string) => {
-    if (groupName.includes('สุขภาพจิต') || groupName.includes('ยาเสพติด')) {
-      return <Users className="h-6 w-6" />;
+    if (groupName.includes('สุขภาพจิต')) {
+      return <Brain className="h-6 w-6" />;
+    }
+    if (groupName.includes('ยาเสพติด')) {
+      return <Pill className="h-6 w-6" />;
     }
     if (groupName.includes('มะเร็ง')) {
-      return <Activity className="h-6 w-6" />;
+      return <Ribbon className="h-6 w-6" />;
     }
     return <Target className="h-6 w-6" />;
   };


### PR DESCRIPTION
## Summary
- replace FontAwesome icons in KPI detail table with lucide-react equivalents
- assign meaningful lucide icons to KPI group categories

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4f897508832186e39bd2d57621db