### PR TITLE
Enhance responsiveness and prevent text overflow

### DIFF
--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -13,9 +13,13 @@ export const DashboardHeader = ({ summary }: DashboardHeaderProps) => {
   return (
     <div className="space-y-6">
       {/* Header Section */}
-      <div className="bg-gradient-to-r from-primary to-primary-hover text-primary-foreground p-8 rounded-lg shadow-lg">
-        <h1 className="text-3xl font-bold mb-2">Dashboard ติดตามประเด็นขับเคลื่อนตัวชี้วัด</h1>
-        <p className="text-lg opacity-90">คณะกรรมการประสานงานสาธารณสุขระดับอำเภอสอง</p>
+      <div className="bg-gradient-to-r from-primary to-primary-hover text-primary-foreground p-6 sm:p-8 rounded-lg shadow-lg">
+        <h1 className="text-2xl sm:text-3xl font-bold mb-2 break-words">
+          Dashboard ติดตามประเด็นขับเคลื่อนตัวชี้วัด
+        </h1>
+        <p className="text-base sm:text-lg opacity-90">
+          คณะกรรมการประสานงานสาธารณสุขระดับอำเภอสอง
+        </p>
       </div>
 
       {/* Stats Cards */}

--- a/src/components/dashboard/FilterPanel.tsx
+++ b/src/components/dashboard/FilterPanel.tsx
@@ -150,7 +150,7 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               value={filters.selectedGroup} 
               onValueChange={(value) => handleFilterChange('selectedGroup', value)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full text-left">
                 <SelectValue placeholder="เลือกประเด็นขับเคลื่อน" />
               </SelectTrigger>
               <SelectContent className="bg-white">
@@ -177,7 +177,7 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               value={filters.selectedMainKPI} 
               onValueChange={(value) => handleFilterChange('selectedMainKPI', value)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full text-left">
                 <SelectValue placeholder="เลือกตัวชี้วัดหลัก" />
               </SelectTrigger>
               <SelectContent className="bg-white">
@@ -204,7 +204,7 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               value={filters.selectedSubKPI} 
               onValueChange={(value) => handleFilterChange('selectedSubKPI', value)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full text-left">
                 <SelectValue placeholder="เลือกตัวชี้วัดย่อย" />
               </SelectTrigger>
               <SelectContent className="bg-white">
@@ -231,7 +231,7 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               value={filters.selectedTarget} 
               onValueChange={(value) => handleFilterChange('selectedTarget', value)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full text-left">
                 <SelectValue placeholder="เลือกกลุ่มเป้าหมาย" />
               </SelectTrigger>
               <SelectContent className="bg-white">
@@ -258,7 +258,7 @@ export const FilterPanel = ({ data, filters, onFiltersChange }: FilterPanelProps
               value={filters.selectedService}
               onValueChange={(value) => handleFilterChange("selectedService", value)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full text-left">
                 <SelectValue placeholder="เลือกหน่วยบริการ" />
               </SelectTrigger>
               <SelectContent className="bg-white">

--- a/src/components/dashboard/KPIDetailTable.tsx
+++ b/src/components/dashboard/KPIDetailTable.tsx
@@ -3,7 +3,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { KPIRecord } from "@/types/kpi";
+import { KPIRecord, SummaryStats } from "@/types/kpi";
 import { calculatePercentage } from "@/lib/kpi";
 import {
   AlertCircle,
@@ -12,27 +12,45 @@ import {
   Info,
   Table,
   Users,
+  Activity,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 interface KPIDetailTableProps {
   data: KPIRecord[];
   groupName?: string;
+  groupIcon?: LucideIcon;
+  summary?: SummaryStats;
   onBack?: () => void;
   onKPIInfoClick: (kpiInfoId: string) => void;
   onRawDataClick: (sheetSource: string, record?: KPIRecord) => void;
 }
 
-export const KPIDetailTable = ({ 
-  data, 
-  groupName, 
-  onBack, 
-  onKPIInfoClick, 
-  onRawDataClick 
+export const KPIDetailTable = ({
+  data,
+  groupName,
+  groupIcon,
+  summary,
+  onBack,
+  onKPIInfoClick,
+  onRawDataClick
 }: KPIDetailTableProps) => {
   const [sortField, setSortField] = useState<keyof KPIRecord | null>(null);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
+
+  const groupStats = groupName ? summary?.groupStats[groupName] : undefined;
+  const totalKPIs = groupStats?.count ?? 0;
+  const averagePercentage = groupStats?.averagePercentage ?? 0;
+  const passedCount = groupStats?.passed ?? 0;
+  const IconComponent = groupIcon ?? Activity;
+
+  const getStatusColor = (percentage: number) => {
+    if (percentage >= 80) return 'text-success';
+    if (percentage >= 60) return 'text-warning';
+    return 'text-destructive';
+  };
 
   // Group by main KPI first, then by sub KPI
   const groupedData = data.reduce((acc, item) => {
@@ -78,17 +96,50 @@ export const KPIDetailTable = ({
               กลับ
             </Button>
           )}
-          <div>
-            <h2 className="text-2xl font-bold">รายละเอียดตัวชี้วัด</h2>
-            {groupName && (
-              <p className="text-muted-foreground mt-1">ประเด็นขับเคลื่อน: {groupName}</p>
-            )}
-          </div>
+          <h2 className="text-2xl font-bold">รายละเอียดตัวชี้วัด</h2>
         </div>
         <div className="text-sm text-muted-foreground">
           รวม {data.length} รายการ
         </div>
       </div>
+
+      {groupName && (
+        <Card className="p-6">
+          <div className="flex items-center space-x-3 mb-4">
+            <div className="p-2 bg-primary/10 rounded-lg text-primary flex-shrink-0">
+              <IconComponent className="h-6 w-6" />
+            </div>
+            <h3 className="font-semibold text-base sm:text-lg leading-tight break-words flex-1">
+              {groupName}
+            </h3>
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex justify-between items-center text-sm">
+              <div className="flex items-center space-x-2">
+                <span className="text-muted-foreground">ตัวชี้วัด:</span>
+                <span className="font-medium">{totalKPIs}</span>
+              </div>
+              <div className="flex items-center space-x-2">
+                <span className="text-muted-foreground">ผ่าน:</span>
+                <span className={`font-medium ${getStatusColor(averagePercentage)}`}>
+                  {passedCount}/{totalKPIs}
+                </span>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-muted-foreground">ความสำเร็จเฉลี่ย</span>
+                <span className={`text-lg font-bold ${getStatusColor(averagePercentage)}`}>
+                  {averagePercentage.toFixed(1)}%
+                </span>
+              </div>
+              <Progress value={Math.min(averagePercentage, 100)} className="h-2" />
+            </div>
+          </div>
+        </Card>
+      )}
 
       {/* Main KPI Groups */}
       <div className="space-y-8 border border-primary/20 rounded-lg p-4">
@@ -117,8 +168,8 @@ export const KPIDetailTable = ({
                             size="sm"
                             onClick={() => onRawDataClick(groupSheetSource)}
                           >
-                            <Table className="h-4 w-4 mr-1" />
-                            ข้อมูลทั้งหมด
+                            <Table className="h-4 w-4 mr-0 sm:mr-1" />
+                            <span className="hidden sm:inline">ข้อมูลทั้งหมด</span>
                           </Button>
                         )}
                         {records[0]?.kpi_info_id && (
@@ -127,8 +178,8 @@ export const KPIDetailTable = ({
                             size="sm"
                             onClick={() => onKPIInfoClick(records[0].kpi_info_id)}
                           >
-                            <Info className="h-4 w-4 mr-1" />
-                            รายละเอียด KPI
+                            <Info className="h-4 w-4 mr-0 sm:mr-1" />
+                            <span className="hidden sm:inline">รายละเอียด KPI</span>
                           </Button>
                         )}
                       </div>
@@ -159,13 +210,13 @@ export const KPIDetailTable = ({
                             (record as Record<string, string | undefined>)['แหล่งข้อมูล']?.trim();
                           return (
                             <tr key={index} className="border-b hover:bg-muted/30 transition-colors">
-                              <td className="p-3">
+                              <td className="p-3 align-top">
                                 <div className="flex items-center space-x-2">
-                                  <Users className="h-4 w-4 text-muted-foreground" />
-                                  <span>{record['กลุ่มเป้าหมาย']}</span>
+                                  <Users className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                                  <span className="break-words">{record['กลุ่มเป้าหมาย']}</span>
                                 </div>
                               </td>
-                              <td className="p-3 font-medium">{record['ชื่อหน่วยบริการ']}</td>
+                              <td className="p-3 font-medium break-words">{record['ชื่อหน่วยบริการ']}</td>
                               <td className="p-3 text-right font-mono">
                                 {formatNumber(record['เป้าหมาย'])}
                               </td>

--- a/src/components/dashboard/KPIGroupCards.tsx
+++ b/src/components/dashboard/KPIGroupCards.tsx
@@ -30,7 +30,7 @@ import { KPIRecord, SummaryStats } from "@/types/kpi";
 interface KPIGroupCardsProps {
   data: KPIRecord[];
   summary: SummaryStats;
-  onGroupClick: (groupName: string) => void;
+  onGroupClick: (groupName: string, icon: LucideIcon) => void;
 }
 
 export const KPIGroupCards = ({ data, summary, onGroupClick }: KPIGroupCardsProps) => {
@@ -87,7 +87,9 @@ export const KPIGroupCards = ({ data, summary, onGroupClick }: KPIGroupCardsProp
 
   return (
     <div className="space-y-6">
-      <h2 className="text-2xl font-bold text-foreground">ประเด็นขับเคลื่อนหลัก</h2>
+      <h2 className="text-xl sm:text-2xl font-bold text-foreground break-words">
+        ประเด็นขับเคลื่อนหลัก
+      </h2>
       
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {Object.entries(groupedData).map(([groupName, records]) => {
@@ -101,20 +103,20 @@ export const KPIGroupCards = ({ data, summary, onGroupClick }: KPIGroupCardsProp
             <Card
               key={groupName}
               className="p-6 hover:shadow-lg transition-all duration-200 cursor-pointer group border-l-4 border-l-primary"
-              onClick={() => onGroupClick(groupName)}
+              onClick={() => onGroupClick(groupName, IconComponent)}
             >
               <div className="flex items-start justify-between mb-4">
-                <div className="flex items-center space-x-3">
-                  <div className="p-2 bg-primary/10 rounded-lg text-primary">
+                <div className="flex items-center space-x-3 min-w-0 flex-1">
+                  <div className="p-2 bg-primary/10 rounded-lg text-primary flex-shrink-0">
                     <IconComponent className="h-6 w-6" />
                   </div>
-                  <div className="flex-1">
-                    <h3 className="font-semibold text-lg leading-tight group-hover:text-primary transition-colors">
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-base sm:text-lg leading-tight group-hover:text-primary transition-colors break-words">
                       {groupName}
                     </h3>
                   </div>
                 </div>
-                <ChevronRight className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+                <ChevronRight className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors flex-shrink-0" />
               </div>
 
               <div className="space-y-4">

--- a/src/components/modals/RawDataModal.tsx
+++ b/src/components/modals/RawDataModal.tsx
@@ -9,9 +9,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
-import { Search, Database, Download, Calendar, AlertCircle } from "lucide-react";
+import { Search, Database, Download, AlertCircle } from "lucide-react";
 import { KPIRecord } from "@/types/kpi";
 import { useSourceData } from "@/hooks/useKPIData";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -90,7 +89,7 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
         <DialogContent className="max-w-none w-[calc(100vw-4rem)] h-[calc(100vh-4rem)]">
           <DialogHeader className="sr-only">
             <DialogTitle>กำลังโหลดข้อมูล</DialogTitle>
-            <DialogDescription>กำลังโหลดข้อมูลดิบ</DialogDescription>
+            <DialogDescription>กำลังโหลดข้อมูล</DialogDescription>
           </DialogHeader>
           <div className="flex items-center justify-center p-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -126,16 +125,18 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-none w-[calc(100vw-4rem)] h-[calc(100vh-4rem)] p-0 flex flex-col">
         <DialogHeader className="p-6 pb-0">
-          <DialogTitle className="text-xl font-bold flex items-center">
-            <Database className="h-5 w-5 mr-2" />
-            ข้อมูลดิบ: {sheetSource}
+          <DialogTitle className="text-xl font-bold flex flex-col sm:flex-row sm:items-center">
+            <span className="flex items-center">
+              <Database className="h-5 w-5 mr-2" />ข้อมูล:
+            </span>
+            <span className="sm:ml-2">{sheetSource}</span>
           </DialogTitle>
           <DialogDescription className="sr-only">
-            ข้อมูลดิบจาก {sheetSource}
+            ข้อมูลจาก {sheetSource}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="px-6 space-y-4">
+        <div className="px-4 sm:px-6 space-y-4">
           {/* Info Card */}
           {record && (
             <Card className="p-4 bg-primary/5 border-primary/20">
@@ -167,9 +168,9 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
           )}
 
           {/* Search and Actions */}
-          <div className="flex items-center justify-between space-x-4">
-            <div className="relative flex-1 max-w-md">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div className="relative flex-1 w-full sm:max-w-md">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground h-4 w-4" />
               <Input
                 placeholder="ค้นหาในข้อมูล..."
                 value={searchTerm}
@@ -177,11 +178,11 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
                 className="pl-10"
               />
             </div>
-            <div className="flex items-center space-x-2">
-              <Badge variant="outline" className="text-xs">
+            <div className="flex items-center justify-between gap-2 w-full sm:w-auto">
+              <Badge variant="outline" className="text-xs whitespace-nowrap">
                 {filteredData.length} / {viewData.length} รายการ
               </Badge>
-              <Button variant="outline" size="sm" onClick={handleExport}>
+              <Button variant="outline" size="sm" onClick={handleExport} className="whitespace-nowrap">
                 <Download className="h-4 w-4 mr-1" />
                 Export Excel
               </Button>
@@ -190,16 +191,15 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
         </div>
 
         {/* Data Table */}
-        <ScrollArea className="flex-1 px-6">
+        <div className="flex-1 px-4 sm:px-6 min-h-0">
           {filteredData.length > 0 ? (
-            <div className="pb-6">
-              <div className="border rounded-lg overflow-hidden">
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead className="bg-muted/50 sticky top-0">
+            <div className="pb-6 h-full flex flex-col min-h-0">
+              <div className="border rounded-lg flex-1 overflow-auto">
+                <table className="min-w-max w-full text-sm">
+                  <thead className="bg-muted sticky top-0">
                       <tr>
                         {headers.map((header, index) => (
-                          <th 
+                          <th
                             key={index}
                             className="text-left p-3 font-medium border-r border-border last:border-r-0 min-w-[120px]"
                           >
@@ -207,45 +207,44 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
                           </th>
                         ))}
                       </tr>
-                    </thead>
-                    <tbody>
-                      {filteredData.map((row, rowIndex) => (
-                        <tr 
-                          key={rowIndex} 
-                          className="border-b hover:bg-muted/30 transition-colors"
-                        >
-                          {headers.map((header, colIndex) => {
-                            const value = row[header];
-                            const isNumber = !isNaN(Number(value)) && value !== '' && value !== null;
-                            
-                            return (
-                              <td 
-                                key={colIndex}
-                                className={`p-3 border-r border-border last:border-r-0 ${
-                                  isNumber ? 'text-right font-mono' : 'text-left'
-                                }`}
-                              >
-                                {value || '-'}
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                  </thead>
+                  <tbody>
+                    {filteredData.map((row, rowIndex) => (
+                      <tr
+                        key={rowIndex}
+                        className="border-b hover:bg-muted/30 transition-colors"
+                      >
+                        {headers.map((header, colIndex) => {
+                          const value = row[header];
+                          const isNumber = !isNaN(Number(value)) && value !== '' && value !== null;
+
+                          return (
+                            <td
+                              key={colIndex}
+                              className={`p-3 border-r border-border last:border-r-0 ${
+                                isNumber ? 'text-right font-mono' : 'text-left'
+                              }`}
+                            >
+                              {value || '-'}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
 
               {/* Summary Info */}
-              <div className="mt-4 pt-4 border-t text-xs text-muted-foreground flex items-center justify-between">
-                <div className="flex items-center space-x-4">
-                  <span>รวม {filteredData.length} รายการ</span>
-                  <span>•</span>
+              <div className="mt-4 pt-4 border-t text-xs text-muted-foreground flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                  <span>{filteredData.length} รายการ</span>
+                  <span className="hidden sm:inline">•</span>
                   <span>{headers.length} คอลัมน์</span>
                 </div>
-                <div className="flex items-center">
-                  <Calendar className="h-3 w-3 mr-1" />
-                  ดึงข้อมูลเมื่อ: {new Date().toLocaleString('th-TH')}
+                <div className="flex items-center sm:ml-auto sm:justify-end text-right">
+                  <span className="mr-1">ข้อมูล</span>
+                  <span>{new Date().toLocaleString('th-TH')}</span>
                 </div>
               </div>
             </div>
@@ -256,9 +255,9 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
                 {viewData.length === 0 ? 'ไม่พบข้อมูลในแหล่งข้อมูลนี้' : 'ไม่พบข้อมูลที่ตรงกับการค้นหา'}
               </p>
               {searchTerm && (
-                <Button 
-                  variant="outline" 
-                  size="sm" 
+                <Button
+                  variant="outline"
+                  size="sm"
                   onClick={() => setSearchTerm('')}
                   className="mt-2"
                 >
@@ -267,7 +266,7 @@ export const RawDataModal = ({ isOpen, onClose, sheetSource, record }: RawDataMo
               )}
             </div>
           )}
-        </ScrollArea>
+        </div>
 
         {/* Footer */}
         <div className="p-6 pt-0 flex justify-end">

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,6 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Loader2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useKPIData, useKPIInfo } from "@/hooks/useKPIData";
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { FilterPanel } from "@/components/dashboard/FilterPanel";
@@ -86,6 +87,7 @@ const Index = () => {
   // Navigation state
   const [currentView, setCurrentView] = useState<'groups' | 'detail'>('groups');
   const [selectedGroup, setSelectedGroup] = useState<string>('');
+  const [selectedGroupIcon, setSelectedGroupIcon] = useState<LucideIcon | null>(null);
   
   // Modal states
   const [showKPIInfo, setShowKPIInfo] = useState(false);
@@ -161,8 +163,9 @@ const Index = () => {
     });
   };
 
-  const handleGroupClick = (groupName: string) => {
+  const handleGroupClick = (groupName: string, icon: LucideIcon) => {
     setSelectedGroup(groupName);
+    setSelectedGroupIcon(icon);
     setFilters(prev => ({ ...prev, selectedGroup: groupName }));
     setCurrentView('detail');
   };
@@ -170,6 +173,7 @@ const Index = () => {
   const handleBackToGroups = () => {
     setCurrentView('groups');
     setSelectedGroup('');
+    setSelectedGroupIcon(null);
     setFilters(initialFilters);
   };
 
@@ -250,9 +254,11 @@ const Index = () => {
             onGroupClick={handleGroupClick}
           />
         ) : (
-          <KPIDetailTable 
+          <KPIDetailTable
             data={filteredData}
             groupName={selectedGroup}
+            groupIcon={selectedGroupIcon ?? undefined}
+            summary={filteredSummary}
             onBack={handleBackToGroups}
             onKPIInfoClick={handleKPIInfoClick}
             onRawDataClick={handleRawDataClick}


### PR DESCRIPTION
## Summary
- Add summary card from key driver section to KPI detail view with matching icon and stats
- Pass group icon from KPI overview cards to detail pages for consistent visuals
- Hide raw data and KPI detail button labels on mobile, showing only icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb373b1d88321a2b0bda78b354a4d