### PR TITLE
fix: remove duplicate helpers in KPI detail table

### DIFF
--- a/src/components/dashboard/KPIGroupCards.tsx
+++ b/src/components/dashboard/KPIGroupCards.tsx
@@ -31,7 +31,7 @@ import { KPIRecord, SummaryStats } from "@/types/kpi";
 interface KPIGroupCardsProps {
   data: KPIRecord[];
   stats: SummaryStats;
-  onGroupClick: (groupName: string) => void;
+  onGroupClick: (groupName: string, icon: LucideIcon) => void;
 }
 
 export const KPIGroupCards = ({ data, stats, onGroupClick }: KPIGroupCardsProps) => {
@@ -106,7 +106,7 @@ export const KPIGroupCards = ({ data, stats, onGroupClick }: KPIGroupCardsProps)
             <Card
               key={groupName}
               className="p-6 hover:shadow-lg transition-all duration-200 cursor-pointer group border-l-4 border-l-primary"
-              onClick={() => onGroupClick(groupName, IconComponent)}
+              onClick={() => onGroupClick(groupName, GroupIcon)}
             >
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center space-x-3 min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- remove repeated helper declarations in `KPIDetailTable`
- compute KPI summary stats once and colorize status
- forward correct group icon when selecting group to avoid runtime `IconComponent` ReferenceError

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af10c637c48321ba5334ca18495af3